### PR TITLE
Added --harmony flag to start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Example server for the graffiti GraphQL ORM",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js",
+    "start": "node --harmony server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
HI, I started playing around with the example today and noticed that without the --harmony flag I get a syntax error when running npm start. Adding this starts the application server without any issues.

Great work on graffiti! :)